### PR TITLE
test: reset mongoose readyState after tests

### DIFF
--- a/test/integration/workflows.test.js
+++ b/test/integration/workflows.test.js
@@ -44,6 +44,11 @@ describe('Critical Workflows Integration', () => {
     };
   });
 
+  afterEach(() => {
+    mongoose.connection.readyState = 1; // reset connection state on mock
+    require('mongoose').connection.readyState = 1; // also reset on imported module
+  });
+
   describe('User Management Workflow', () => {
     test('should handle complete user lifecycle', async () => {
       // Create user

--- a/test/unit/database-utils.test.js
+++ b/test/unit/database-utils.test.js
@@ -32,6 +32,11 @@ describe('Database Utils module', () => {
     jest.clearAllMocks();
   });
 
+  afterEach(() => {
+    mongoose.connection.readyState = 1; // reset connection state on mock
+    require('mongoose').connection.readyState = 1; // also reset on imported module
+  });
+
   describe('ensureMongoDB function', () => {
     test('should return true when database is connected', () => {
       // Reset mock before test


### PR DESCRIPTION
## Summary
- reset `mongoose.connection.readyState` after each test in integration and unit suites

## Testing
- `npm test` *(fails: Database Utils module › ensureMongoDB function › should handle connection state check errors)*

------
https://chatgpt.com/codex/tasks/task_b_684577374588832283e5e6edb59d356c