### PR TITLE
Add logging to all exported functions

### DIFF
--- a/lib/database-utils.js
+++ b/lib/database-utils.js
@@ -58,6 +58,7 @@ const { sendServiceUnavailable, sendInternalServerError, sendConflict } = requir
  * Usage pattern: Controllers should check this before database operations
  */
 function ensureMongoDB(res) {
+  console.log('ensureMongoDB is running'); // log start with no params
   // Log current connection state for debugging and monitoring purposes
   // readyState values: 0=disconnected, 1=connected, 2=connecting, 3=disconnecting
   console.log(`Checking database availability - connection state: ${mongoose.connection.readyState}`);
@@ -69,10 +70,12 @@ function ensureMongoDB(res) {
       // Use centralized HTTP utility for consistent error responses
       sendServiceUnavailable(res, 'Database functionality unavailable');
       console.log('Database check failed - connection not ready');
+      console.log('ensureMongoDB is returning false'); // log before return false
       return false; // Signal to caller that DB operations should not proceed
     }
 
     console.log('Database check passed - connection ready');
+    console.log('ensureMongoDB is returning true'); // log before returning true
     return true; // Database is connected and ready
   } catch (error) {
     // Handle unexpected errors during connection state checking
@@ -81,6 +84,7 @@ function ensureMongoDB(res) {
 
     // Use centralized HTTP utility for consistent error responses
     sendInternalServerError(res, 'Error checking database connection');
+    console.log('ensureMongoDB is returning false'); // log before return false in catch
     return false; // Unexpected error occurred during DB check
   }
 }
@@ -116,6 +120,7 @@ function ensureMongoDB(res) {
  * @returns {Promise<boolean>} Promise resolving to true if unique, false if duplicate exists
  */
 async function ensureUnique(model, query, res, duplicateMsg) {
+  console.log('ensureUnique is running'); // log start without detail to avoid clutter
   // Log the query for debugging and monitoring duplicate attempt patterns
   console.log(`ensureUnique is checking query: ${JSON.stringify(query)}`);
 
@@ -128,15 +133,18 @@ async function ensureUnique(model, query, res, duplicateMsg) {
       // Use centralized HTTP utility for consistent conflict responses
       sendConflict(res, duplicateMsg);
       console.log('ensureUnique found duplicate');
+      console.log('ensureUnique is returning false'); // log before returning false
       return false; // Duplicate exists - caller should respond with 409
     }
 
     console.log('ensureUnique passed - no duplicates');
+    console.log('ensureUnique is returning true'); // log before return true
     return true; // Safe to proceed with create or update
   } catch (error) {
     // Re-throw database errors to be handled by calling function
     // This allows for proper error handling context in the calling code
     console.error('ensureUnique error', error); // Allow higher layers to handle DB error
+    // No console.log return here because function throws
     throw error; // Propagate error to caller
   }
 }

--- a/lib/document-ops.js
+++ b/lib/document-ops.js
@@ -61,6 +61,7 @@ const { logFunctionEntry, logFunctionExit, logFunctionError } = require('./loggi
  * @returns {Promise<Object|null>} Document result or null if not found/invalid ID
  */
 async function performUserDocOp(model, id, username, opCallback) {
+  console.log(`performUserDocOp is running with id: ${id} user: ${username}`); // log function start
   // Log operation start with parameters for debugging and audit trails
   logFunctionEntry(opCallback.name, { id, username });
   
@@ -70,6 +71,7 @@ async function performUserDocOp(model, id, username, opCallback) {
     
     // Log successful operation result
     logFunctionExit(opCallback.name, doc);
+    console.log(`performUserDocOp is returning ${doc}`); // log before returning result
     return doc; // Return fetched document to calling controller
   } catch (error) {
     // Log error details for debugging while handling gracefully
@@ -79,6 +81,7 @@ async function performUserDocOp(model, id, username, opCallback) {
     // This prevents information leakage about valid vs invalid IDs
     if (error instanceof mongoose.Error.CastError) {
       logFunctionExit(opCallback.name, 'null due to CastError');
+      console.log('performUserDocOp is returning null'); // log null case
       return null;
     }
     
@@ -111,6 +114,7 @@ async function performUserDocOp(model, id, username, opCallback) {
  * @returns {Promise<Object|null>} Document if found and owned by user, null otherwise
  */
 async function findUserDoc(model, id, username) {
+  console.log(`findUserDoc is running with id: ${id} user: ${username}`); // log start
   // Define the operation as a named function for better logging and debugging
   const op = async function findUserDoc(m, i, u) {
     // Query for document with both ID and user ownership constraints
@@ -119,6 +123,7 @@ async function findUserDoc(model, id, username) {
   };
   
   // Execute with standardized error handling and logging
+  console.log('findUserDoc is returning result from performUserDocOp'); // log before returning wrapped result
   return performUserDocOp(model, id, username, op); // Use shared wrapper to avoid duplicate try/catch logic
 }
 
@@ -144,6 +149,7 @@ async function findUserDoc(model, id, username) {
  * @returns {Promise<Object|null>} Deleted document if found and owned by user, null otherwise
  */
 async function deleteUserDoc(model, id, username) {
+  console.log(`deleteUserDoc is running with id: ${id} user: ${username}`); // log start
   // Define the operation as a named function for clear logging
   const op = async function deleteUserDoc(m, i, u) {
     // Use findOneAndDelete for atomic operation with ownership constraint
@@ -152,6 +158,7 @@ async function deleteUserDoc(model, id, username) {
   };
   
   // Execute with standardized error handling
+  console.log('deleteUserDoc is returning result from performUserDocOp'); // log before return
   return performUserDocOp(model, id, username, op);
 }
 
@@ -181,6 +188,7 @@ async function deleteUserDoc(model, id, username) {
  * @returns {Promise<Object|undefined>} Document if found, undefined if 404 sent
  */
 async function userDocActionOr404(model, id, user, res, action, msg) {
+  console.log(`userDocActionOr404 is running with id: ${id} user: ${user}`); // log start
   // Log operation start for debugging and request tracing
   logFunctionEntry('userDocActionOr404', { id, user });
   
@@ -193,11 +201,13 @@ async function userDocActionOr404(model, id, user, res, action, msg) {
       // Send 404 response with custom message and stop execution
       sendNotFound(res, msg);
       logFunctionExit('userDocActionOr404', 'undefined');
+      console.log('userDocActionOr404 is returning undefined'); // log before return
       return; // undefined return indicates 404 response was sent
     }
-    
+
     // Log successful operation and return document
     logFunctionExit('userDocActionOr404', doc);
+    console.log(`userDocActionOr404 is returning ${doc}`); // log before returning doc
     return doc;
   } catch (error) {
     // Log error and re-throw for higher-level error handling
@@ -225,6 +235,7 @@ async function userDocActionOr404(model, id, user, res, action, msg) {
  * @returns {Promise<Object|undefined>} Document if found, undefined if 404 sent
  */
 async function fetchUserDocOr404(model, id, user, res, msg) {
+  console.log(`fetchUserDocOr404 is running with id: ${id} user: ${user}`); // log start
   logFunctionEntry('fetchUserDocOr404', { id, user });
   
   try {
@@ -234,10 +245,12 @@ async function fetchUserDocOr404(model, id, user, res, msg) {
     // Check if 404 response was sent (doc would be undefined)
     if (!doc) {
       logFunctionExit('fetchUserDocOr404', 'undefined');
+      console.log('fetchUserDocOr404 is returning undefined'); // log before return undefined
       return;
     }
-    
+
     logFunctionExit('fetchUserDocOr404', doc);
+    console.log(`fetchUserDocOr404 is returning ${doc}`); // log before returning doc
     return doc;
   } catch (error) {
     logFunctionError('fetchUserDocOr404', error);
@@ -260,6 +273,7 @@ async function fetchUserDocOr404(model, id, user, res, msg) {
  * @returns {Promise<Object|undefined>} Deleted document if found, undefined if 404 sent
  */
 async function deleteUserDocOr404(model, id, user, res, msg) {
+  console.log(`deleteUserDocOr404 is running with id: ${id} user: ${user}`); // log start
   logFunctionEntry('deleteUserDocOr404', { id, user });
   
   try {
@@ -268,10 +282,12 @@ async function deleteUserDocOr404(model, id, user, res, msg) {
     
     if (!doc) {
       logFunctionExit('deleteUserDocOr404', 'undefined');
+      console.log('deleteUserDocOr404 is returning undefined'); // log before return
       return;
     }
-    
+
     logFunctionExit('deleteUserDocOr404', doc);
+    console.log(`deleteUserDocOr404 is returning ${doc}`); // log before returning doc
     return doc; // Provide deleted document back to caller for confirmation
   } catch (error) {
     logFunctionError('deleteUserDocOr404', error);
@@ -303,6 +319,7 @@ async function deleteUserDocOr404(model, id, user, res, msg) {
  * @returns {Promise<Array>} Array of documents owned by the user (may be empty)
  */
 async function listUserDocs(model, username, sort) {
+  console.log(`listUserDocs is running with user: ${username}`); // log start
   // Log operation with sort configuration for debugging
   logFunctionEntry('listUserDocs', { username, sort: JSON.stringify(sort) });
   
@@ -312,6 +329,7 @@ async function listUserDocs(model, username, sort) {
     const docs = await model.find({ user: username }).sort(sort);
     
     logFunctionExit('listUserDocs', docs);
+    console.log(`listUserDocs is returning ${docs}`); // log before return
     return docs; // Returning array keeps caller logic simple
   } catch (error) {
     logFunctionError('listUserDocs', error);
@@ -345,6 +363,7 @@ async function listUserDocs(model, username, sort) {
  * @returns {Promise<Object|undefined>} Created document if successful, undefined if duplicate
  */
 async function createUniqueDoc(model, fields, uniqueQuery, res, duplicateMsg) {
+  console.log('createUniqueDoc is running'); // log start with no heavy params
   logFunctionEntry('createUniqueDoc', { fields: JSON.stringify(fields) });
   
   try {
@@ -352,6 +371,7 @@ async function createUniqueDoc(model, fields, uniqueQuery, res, duplicateMsg) {
     if (!(await ensureUnique(model, uniqueQuery, res, duplicateMsg))) {
       // ensureUnique sent 409 response, return undefined to signal this
       logFunctionExit('createUniqueDoc', 'undefined');
+      console.log('createUniqueDoc is returning undefined'); // log before return
       return;
     }
     
@@ -362,6 +382,7 @@ async function createUniqueDoc(model, fields, uniqueQuery, res, duplicateMsg) {
     const saved = await doc.save();
     
     logFunctionExit('createUniqueDoc', saved);
+    console.log(`createUniqueDoc is returning ${saved}`); // log before returning saved doc
     return saved; // Return persisted document for caller usage
   } catch (error) {
     logFunctionError('createUniqueDoc', error);
@@ -403,6 +424,7 @@ async function createUniqueDoc(model, fields, uniqueQuery, res, duplicateMsg) {
  * @returns {Promise<Object|undefined>} Updated document if successful, undefined if error response sent
  */
 async function updateUserDoc(model, id, username, fieldsToUpdate, uniqueQuery, res, duplicateMsg) {
+  console.log(`updateUserDoc is running with id: ${id} user: ${username}`); // log start
   logFunctionEntry('updateUserDoc', { id, username });
   
   try {
@@ -412,6 +434,7 @@ async function updateUserDoc(model, id, username, fieldsToUpdate, uniqueQuery, r
     // If document not found, fetchUserDocOr404 already sent 404 response
     if (!doc) {
       logFunctionExit('updateUserDoc', 'undefined');
+      console.log('updateUserDoc is returning undefined'); // log before return when not found
       return;
     }
     
@@ -432,6 +455,7 @@ async function updateUserDoc(model, id, username, fieldsToUpdate, uniqueQuery, r
       // This optimization avoids unnecessary database queries for updates that don't affect unique fields
       if (!(await ensureUnique(model, uniqueQueryWithExclusion, res, duplicateMsg))) {
         logFunctionExit('updateUserDoc', 'undefined');
+        console.log('updateUserDoc is returning undefined'); // log before return duplicate case
         return;
       }
     }
@@ -444,6 +468,7 @@ async function updateUserDoc(model, id, username, fieldsToUpdate, uniqueQuery, r
     await doc.save();
     
     logFunctionExit('updateUserDoc', doc);
+    console.log(`updateUserDoc is returning ${doc}`); // log before returning updated doc
     return doc; // Provide updated document for downstream logic
   } catch (error) {
     logFunctionError('updateUserDoc', error);

--- a/lib/http-utils.js
+++ b/lib/http-utils.js
@@ -46,8 +46,10 @@
  * @param {string} message - Custom error message describing what was not found
  */
 function sendNotFound(res, message) {
+  console.log(`sendNotFound is running with ${message}`); // log start with message
   // Send standardized 404 Not Found response with custom message
   // This centralizes error response formatting and ensures consistency
+  console.log(`sendNotFound is returning response with message ${message}`); // log before returning res
   return res.status(404).json({ message: message }); // Returns res for chaining
 }
 
@@ -61,6 +63,8 @@ function sendNotFound(res, message) {
  * @param {string} message - Custom error message describing the conflict
  */
 function sendConflict(res, message) {
+  console.log(`sendConflict is running with ${message}`); // log start with message
+  console.log(`sendConflict is returning response with message ${message}`); // log before returning res
   return res.status(409).json({ message: message }); // Follows same pattern as sendNotFound
 }
 
@@ -74,6 +78,8 @@ function sendConflict(res, message) {
  * @param {string} message - Custom error message describing the internal error
  */
 function sendInternalServerError(res, message) {
+  console.log(`sendInternalServerError is running with ${message}`); // log start
+  console.log(`sendInternalServerError is returning response with message ${message}`); // log before returning res
   return res.status(500).json({ message: message }); // Indicates unexpected failure to client
 }
 
@@ -87,6 +93,8 @@ function sendInternalServerError(res, message) {
  * @param {string} message - Custom error message describing the unavailable service
  */
 function sendServiceUnavailable(res, message) {
+  console.log(`sendServiceUnavailable is running with ${message}`); // log start
+  console.log(`sendServiceUnavailable is returning response with message ${message}`); // log before returning res
   return res.status(503).json({ message: message }); // For dependency outages or maintenance
 }
 

--- a/lib/logging-utils.js
+++ b/lib/logging-utils.js
@@ -29,11 +29,13 @@
  * @param {Object} params - Parameters passed to the function
  */
 function logFunctionEntry(functionName, params = {}) {
+  console.log(`logFunctionEntry is running with ${functionName}`); // log start
   const paramStr = Object.entries(params)
     .map(([key, value]) => `${key}: ${value}`)
     .join(', ');
   
   console.log(`${functionName} is running with ${paramStr}`); // Entry log for debugging
+  console.log('logFunctionEntry has run resulting in a final value of undefined'); // log end
 }
 
 /**
@@ -46,7 +48,9 @@ function logFunctionEntry(functionName, params = {}) {
  * @param {*} result - Result being returned from the function
  */
 function logFunctionExit(functionName, result) {
+  console.log(`logFunctionExit is running with ${functionName}`); // log start
   console.log(`${functionName} is returning ${result}`); // Exit log tracks return values
+  console.log('logFunctionExit has run resulting in a final value of undefined'); // log end
 }
 
 /**
@@ -59,7 +63,9 @@ function logFunctionExit(functionName, result) {
  * @param {Error} error - Error object that was encountered
  */
 function logFunctionError(functionName, error) {
+  console.log(`logFunctionError is running with ${functionName}`); // log start
   console.error(`${functionName} error`, error); // Error log for troubleshooting
+  console.log('logFunctionError has run resulting in a final value of undefined'); // log end
 }
 
 module.exports = {

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -91,9 +91,12 @@ class MemStorage {
    * @returns {Promise<Object|undefined>} Promise resolving to User object or undefined if not found
    */
   async getUser(id) {
+    console.log(`MemStorage.getUser is running with id: ${id}`); // log start of getUser
     // Direct Map.get() provides O(1) lookup performance
     // Async wrapper maintains interface consistency for future database implementations
-    return this.users.get(id); // Undefined when user doesn't exist for simplicity
+    const result = this.users.get(id);
+    console.log(`MemStorage.getUser is returning ${result}`); // log before return value
+    return result; // Undefined when user doesn't exist for simplicity
   }
 
   /**
@@ -119,11 +122,14 @@ class MemStorage {
    * @returns {Promise<Object|undefined>} Promise resolving to User object or undefined if not found
    */
   async getUserByUsername(username) {
+    console.log(`MemStorage.getUserByUsername is running with username: ${username}`); // log start
     // Convert Map values to array and find first matching username
     // O(n) operation but acceptable for development/testing with limited users
-    return Array.from(this.users.values()).find(
+    const result = Array.from(this.users.values()).find(
       (user) => user.username === username
     ); // Linear search acceptable for small datasets
+    console.log(`MemStorage.getUserByUsername is returning ${result}`); // log before return
+    return result;
   }
 
   /**
@@ -172,8 +178,7 @@ class MemStorage {
    * @returns {Promise<Object>} Promise resolving to complete User object with generated ID
    */
   async createUser(insertUser) {
-    // Log user creation for debugging and audit purposes
-    console.log(`MemStorage.createUser is creating user with username: ${insertUser.username}`);
+    console.log(`MemStorage.createUser is running with username: ${insertUser.username}`); // log start
     
     // Generate unique ID and increment counter for next user
     // Post-increment ensures current user gets the current value
@@ -190,7 +195,7 @@ class MemStorage {
     // Store user in Map with ID as key for efficient retrieval
     this.users.set(id, user);
     
-    console.log(`MemStorage.createUser created user with ID: ${id}`);
+    console.log(`MemStorage.createUser is returning ${JSON.stringify(user)}`); // log before return
     return user; // Provide created user to caller for further processing
   }
 
@@ -206,9 +211,12 @@ class MemStorage {
    * @returns {Promise<Array>} Promise resolving to array of all users
    */
   async getAllUsers() {
+    console.log('MemStorage.getAllUsers is running'); // log start
     // Convert Map values to array for easy consumption
     // Array.from() creates a new array, preserving original Map
-    return Array.from(this.users.values()); // Caller receives snapshot of users
+    const result = Array.from(this.users.values());
+    console.log(`MemStorage.getAllUsers is returning ${JSON.stringify(result)}`); // log before return
+    return result; // Caller receives snapshot of users
   }
 
   /**
@@ -227,12 +235,11 @@ class MemStorage {
    * @returns {Promise<boolean>} Promise resolving to true if deleted, false if not found
    */
   async deleteUser(id) {
-    console.log(`MemStorage.deleteUser deleting user with ID: ${id}`);
+    console.log(`MemStorage.deleteUser is running with id: ${id}`); // log start
     
     // Map.delete() returns true if element existed and was removed, false otherwise
     const result = this.users.delete(id);
-    
-    console.log(`MemStorage.deleteUser result: ${result}`);
+    console.log(`MemStorage.deleteUser is returning ${result}`); // log before return
     return result; // Boolean result informs caller if deletion occurred
   }
 
@@ -251,13 +258,14 @@ class MemStorage {
    * @returns {Promise<void>} Promise resolving when clear operation completes
    */
   async clear() {
-    console.log('MemStorage.clear clearing all users');
+    console.log('MemStorage.clear is running'); // log start
     
     // Clear all users from Map
     this.users.clear();
     
     // Reset ID counter to starting value for predictable testing
     this.currentId = 1; // Reset ensures predictable IDs after clear
+    console.log('MemStorage.clear has run resulting in a final value of undefined'); // log end of void function
   }
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -23,6 +23,8 @@
  * @returns {string} Formatted greeting message
  */
 function greet(name) {
+  console.log(`greet is running with ${name}`); // log start with name
+  console.log(`greet is returning Hello, ${name}!`); // log before return
   return `Hello, ${name}!`; // Simple template literal avoids concat issues
 } // Returns greeting using provided name
 
@@ -37,7 +39,10 @@ function greet(name) {
  * @returns {number} Sum of the two numbers
  */
 function add(a, b) {
-  return a + b; // Uses JS addition which handles floats and ints
+  console.log(`add is running with ${a} and ${b}`); // log start with numbers
+  const result = a + b;
+  console.log(`add is returning ${result}`); // log before return
+  return result; // Uses JS addition which handles floats and ints
 }
 
 /**
@@ -50,7 +55,10 @@ function add(a, b) {
  * @returns {boolean} True if number is even, false otherwise
  */
 function isEven(num) {
-  return num % 2 === 0; // Modulo check works for negatives and positives
+  console.log(`isEven is running with ${num}`); // log start with number
+  const result = num % 2 === 0;
+  console.log(`isEven is returning ${result}`); // log before return
+  return result; // Modulo check works for negatives and positives
 }
 
 module.exports = {

--- a/test/unit/database-utils.test.js
+++ b/test/unit/database-utils.test.js
@@ -57,6 +57,8 @@ describe('Database Utils module', () => { // Tests MongoDB connection and unique
       expect(result).toBe(true);
       expect(mockRes.status).not.toHaveBeenCalled();
       expect(mockRes.json).not.toHaveBeenCalled();
+      expect(console.log).toHaveBeenCalledWith('ensureMongoDB is running'); // verify start log
+      expect(console.log).toHaveBeenCalledWith('ensureMongoDB is returning true'); // verify return log
     });
 
     test('should return false and send 503 when database is disconnected', () => {

--- a/test/unit/document-ops.test.js
+++ b/test/unit/document-ops.test.js
@@ -100,6 +100,8 @@ describe('Document Operations Module', () => { // Unit tests for higher-level do
 
       expect(mockModel.findOne).toHaveBeenCalledWith({ _id: '123', user: 'testuser' });
       expect(result).toEqual(mockDoc);
+      expect(console.log).toHaveBeenCalledWith('findUserDoc is running with id: 123 user: testuser'); // start log
+      expect(console.log).toHaveBeenCalledWith('findUserDoc is returning result from performUserDocOp'); // return log
     });
 
     test('should return null when document not found', async () => {

--- a/test/unit/http-utils.test.js
+++ b/test/unit/http-utils.test.js
@@ -16,11 +16,13 @@ describe('HTTP Utils Module', () => { // Tests standardized HTTP response helper
   describe('sendNotFound function', () => { // Verify 404 helper behavior
     test('should send 404 status with custom message', () => {
       const message = 'User not found';
-      
+
       sendNotFound(mockRes, message);
-      
+
       expect(mockRes.status).toHaveBeenCalledWith(404);
       expect(mockRes.json).toHaveBeenCalledWith({ message });
+      expect(console.log).toHaveBeenCalledWith(`sendNotFound is running with ${message}`); // verify start log
+      expect(console.log).toHaveBeenCalledWith(`sendNotFound is returning response with message ${message}`); // verify return log
     });
 
     test('should handle empty message', () => {

--- a/test/unit/storage.test.js
+++ b/test/unit/storage.test.js
@@ -38,9 +38,9 @@ describe('MemStorage Class', () => { // Tests behavior of the in-memory storage 
         username: 'testuser', // Minimal required field
         displayName: 'Test User' // Optional field included for completeness
       };
-      
+
       const user = await memStorage.createUser(insertUser);
-      
+
       expect(user).toMatchObject({
         id: 1,
         username: 'testuser',
@@ -48,6 +48,8 @@ describe('MemStorage Class', () => { // Tests behavior of the in-memory storage 
         githubId: null,
         avatar: null // Defaults should be null when not provided
       });
+      expect(console.log).toHaveBeenCalledWith('MemStorage.createUser is running with username: testuser'); // start log
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('MemStorage.createUser is returning')); // return log
     });
 
     test('should increment ID for subsequent users', async () => {

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -12,6 +12,8 @@ describe('Utils module', () => { // Tests simple helper functions
     test('should return greeting with provided name', () => {
       expect(greet('Alice')).toBe('Hello, Alice!');
       expect(greet('Bob')).toBe('Hello, Bob!');
+      expect(console.log).toHaveBeenCalledWith('greet is running with Alice'); // start log first call
+      expect(console.log).toHaveBeenCalledWith('greet is returning Hello, Alice!'); // return log first call
     }); // Verifies basic string interpolation logic
 
     test('should handle empty string', () => {


### PR DESCRIPTION
## Summary
- log start/end of HTTP response helpers
- add run/return logs for DB utilities
- update document operations with new logging
- enhance MemStorage and utility functions with logging
- log entry/exit in logging utilities themselves
- update unit tests for logging expectations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68468dc80c708322b27a92c93f0b21ca