### PR TITLE
Improve doc ops documentation

### DIFF
--- a/lib/document-ops.js
+++ b/lib/document-ops.js
@@ -43,6 +43,8 @@ const { logFunctionEntry, logFunctionExit, logFunctionError } = require('./loggi
  * - Provides consistent logging format for debugging and monitoring
  * - Handles MongoDB CastError (invalid ObjectId) gracefully by returning null
  * - Allows any operation function to be wrapped with standard error handling
+ * - User ownership enforcement: passed username ensures queries only touch
+ *   documents owned by that user
  * 
  * Error handling strategy:
  * - CastError (invalid ObjectId): Return null instead of throwing (client sent bad ID)
@@ -70,7 +72,7 @@ async function performUserDocOp(model, id, username, opCallback) {
   try {
     // Execute the provided operation with standard parameters
     // This pattern allows any document operation to benefit from centralized error handling
-    const doc = await opCallback(model, id, username);
+    const doc = await opCallback(model, id, username); // callback performs DB query scoped by username to enforce ownership
     
     // Log successful operation result for monitoring and debugging
     // Helps track successful document operations and return values
@@ -85,10 +87,10 @@ async function performUserDocOp(model, id, username, opCallback) {
     // Handle MongoDB CastError (invalid ObjectId format) by returning null
     // CastError occurs when client sends malformed ObjectId - return null instead of crashing
     // This prevents information leakage about valid vs invalid document IDs
-    if (error instanceof mongoose.Error.CastError) {
+    if (error instanceof mongoose.Error.CastError) { // invalid ObjectId format from client
       logFunctionExit(opCallback.name, 'null due to CastError');
       console.log('performUserDocOp is returning null'); // CastError logging helps debug invalid ID attempts
-      return null; // Null return allows calling code to handle "not found" case gracefully
+      return null; // return null so controllers can respond with 404 without exposing DB errors
     }
     
     // Re-throw other errors to allow proper handling by calling code
@@ -109,6 +111,7 @@ async function performUserDocOp(model, id, username, opCallback) {
  * - Queries both _id AND user fields to enforce ownership
  * - Invalid ObjectIds are handled gracefully without revealing existence of valid IDs
  * - No information leakage about documents belonging to other users
+ * - User ownership enforcement is done directly in the query filter
  * 
  * Performance characteristics:
  * - Uses findOne() which stops at first match
@@ -126,7 +129,7 @@ async function findUserDoc(model, id, username) {
   const op = async function findUserDoc(m, i, u) {
     // Query for document with both ID and user ownership constraints
     // This ensures users can only access their own documents
-    return m.findOne({ _id: i, user: u });
+    return m.findOne({ _id: i, user: u }); // ensures query respects ownership and avoids cross-user access
   };
   
   // Execute with standardized error handling and logging
@@ -144,6 +147,7 @@ async function findUserDoc(model, id, username) {
  * - Uses findOneAndDelete for atomic operation (find + delete in single query)
  * - Returns deleted document to allow confirmation and potential data recovery
  * - Enforces user ownership to prevent unauthorized deletions
+ *   (query includes `user` field so only owner can delete)
  * 
  * Alternative approaches:
  * - Soft delete: Mark as deleted instead of removing (would require schema changes)
@@ -161,7 +165,7 @@ async function deleteUserDoc(model, id, username) {
   const op = async function deleteUserDoc(m, i, u) {
     // Use findOneAndDelete for atomic operation with ownership constraint
     // Returns the deleted document for confirmation
-    return m.findOneAndDelete({ _id: i, user: u });
+    return m.findOneAndDelete({ _id: i, user: u }); // deletion only proceeds when username matches document owner
   };
   
   // Execute with standardized error handling
@@ -182,6 +186,7 @@ async function deleteUserDoc(model, id, username) {
  * - Provides consistent 404 responses across all document operations
  * - Separates HTTP concerns from pure document operations
  * - Allows customizable error messages for different contexts
+ * - Works with user-scoped actions so ownership checks happen before HTTP logic
  * 
  * Usage pattern: This is typically called from Express route handlers where
  * a null result should trigger a 404 response rather than continuing execution.
@@ -201,10 +206,10 @@ async function userDocActionOr404(model, id, user, res, action, msg) {
   
   try {
     // Execute the provided action (findUserDoc, deleteUserDoc, etc.)
-    const doc = await action(model, id, user);
+    const doc = await action(model, id, user); // action includes user filter to enforce ownership
     
     // Check if document was found/operation succeeded
-    if (doc == null) {
+    if (doc == null) { // no doc found for user so send 404
       // Send 404 response with custom message and stop execution
       sendNotFound(res, msg);
       logFunctionExit('userDocActionOr404', 'undefined');
@@ -233,6 +238,7 @@ async function userDocActionOr404(model, id, user, res, action, msg) {
  * Design purpose: Eliminates repetitive null-checking code in controllers
  * by encapsulating the "fetch and 404 if not found" pattern that appears
  * frequently in REST API implementations.
+ * - Enforces user ownership because findUserDoc filters by both id and user
  * 
  * @param {Object} model - Mongoose model to query
  * @param {string} id - Document ID to fetch
@@ -247,10 +253,10 @@ async function fetchUserDocOr404(model, id, user, res, msg) {
   
   try {
     // Use the generic action wrapper with findUserDoc as the specific action
-    const doc = await userDocActionOr404(model, id, user, res, findUserDoc, msg);
+    const doc = await userDocActionOr404(model, id, user, res, findUserDoc, msg); // ensures fetch respects ownership and sends 404
     
     // Check if 404 response was sent (doc would be undefined)
-    if (!doc) {
+    if (!doc) { // 404 already sent
       logFunctionExit('fetchUserDocOr404', 'undefined');
       console.log('fetchUserDocOr404 is returning undefined'); // log before return undefined
       return;
@@ -271,6 +277,7 @@ async function fetchUserDocOr404(model, id, user, res, msg) {
  * This function combines deleteUserDoc with automatic 404 handling, providing
  * the delete equivalent of fetchUserDocOr404. It's commonly used in DELETE
  * endpoints where the absence of a document should result in a 404 response.
+ * - Ownership enforced through deleteUserDoc which filters by user
  * 
  * @param {Object} model - Mongoose model to operate on
  * @param {string} id - Document ID to delete
@@ -285,9 +292,9 @@ async function deleteUserDocOr404(model, id, user, res, msg) {
   
   try {
     // Use the generic action wrapper with deleteUserDoc as the specific action
-    const doc = await userDocActionOr404(model, id, user, res, deleteUserDoc, msg);
+    const doc = await userDocActionOr404(model, id, user, res, deleteUserDoc, msg); // ensures delete is ownership aware
     
-    if (!doc) {
+    if (!doc) { // 404 already sent
       logFunctionExit('deleteUserDocOr404', 'undefined');
       console.log('deleteUserDocOr404 is returning undefined'); // log before return
       return;
@@ -313,6 +320,7 @@ async function deleteUserDocOr404(model, id, user, res, msg) {
  * - Returns array (possibly empty) rather than null for consistent handling
  * - Supports MongoDB sort syntax for flexible ordering
  * - Filters by user ownership to maintain security boundaries
+ *   (query constrains to `user` field so other users' data is never returned)
  * - Does not paginate - consider adding pagination for large document sets
  * 
  * Performance notes:
@@ -333,7 +341,7 @@ async function listUserDocs(model, username, sort) {
   try {
     // Query for all documents owned by user with specified sorting
     // Uses find() to return all matching documents, not just the first
-    const docs = await model.find({ user: username }).sort(sort);
+    const docs = await model.find({ user: username }).sort(sort); // filter by user so only owner's docs return, then sort as requested
     
     logFunctionExit('listUserDocs', docs);
     console.log(`listUserDocs is returning ${docs}`); // log before return
@@ -356,6 +364,7 @@ async function listUserDocs(model, username, sort) {
  * - Provides consistent 409 Conflict responses for duplicate attempts
  * - Returns undefined when duplicate found to signal that HTTP response was sent
  * - Uses new + save pattern for full Mongoose validation and middleware execution
+ * - Uniqueness enforced via ensureUnique helper before document creation
  * 
  * Race condition considerations:
  * - Small window between uniqueness check and save where duplicates could occur
@@ -383,7 +392,7 @@ async function listUserDocs(model, username, sort) {
  * @returns {Promise<boolean>} True if unique, false if duplicate exists
  */
 async function validateDocumentUniqueness(model, uniqueQuery, res, duplicateMsg) {
-  return await ensureUnique(model, uniqueQuery, res, duplicateMsg);
+  return await ensureUnique(model, uniqueQuery, res, duplicateMsg); // checks db for existing doc matching unique fields
 }
 
 /**
@@ -399,10 +408,10 @@ async function validateDocumentUniqueness(model, uniqueQuery, res, duplicateMsg)
  * @returns {boolean} True if any unique fields are being changed, false otherwise
  */
 function hasUniqueFieldChanges(doc, fieldsToUpdate, uniqueQuery) {
-  if (!uniqueQuery) return false;
+  if (!uniqueQuery) return false; // no unique fields specified so no validation needed
   
   return Object.keys(uniqueQuery).some(
-    (key) => key in fieldsToUpdate && doc[key] !== fieldsToUpdate[key]
+    (key) => key in fieldsToUpdate && doc[key] !== fieldsToUpdate[key] // detect change to any unique field
   );
 }
 
@@ -413,7 +422,7 @@ async function createUniqueDoc(model, fields, uniqueQuery, res, duplicateMsg) {
   try {
     // Check for existing documents matching uniqueness criteria before creating
     // Uses extracted helper function to centralize validation logic
-    if (!(await validateDocumentUniqueness(model, uniqueQuery, res, duplicateMsg))) {
+    if (!(await validateDocumentUniqueness(model, uniqueQuery, res, duplicateMsg))) { // duplicate found, response handled inside
       // ensureUnique already sent 409 Conflict response to client
       // Return undefined to signal that HTTP response was already sent
       logFunctionExit('createUniqueDoc', 'undefined');
@@ -423,11 +432,11 @@ async function createUniqueDoc(model, fields, uniqueQuery, res, duplicateMsg) {
     
     // Create new document instance with provided fields
     // Using constructor pattern allows Mongoose validation and middleware to run
-    const doc = new model(fields);
+    const doc = new model(fields); // instantiate to run schema validators
     
     // Save to database with full validation and middleware execution
     // save() triggers pre/post hooks and runs all validation rules
-    const saved = await doc.save();
+    const saved = await doc.save(); // persist to DB and trigger hooks
     
     logFunctionExit('createUniqueDoc', saved);
     console.log(`createUniqueDoc is returning ${saved}`); // Success logging shows created document
@@ -453,6 +462,8 @@ async function createUniqueDoc(model, fields, uniqueQuery, res, duplicateMsg) {
  * - Performs uniqueness check only when relevant fields are being changed
  * - Uses Object.assign for partial updates while preserving unchanged fields
  * - Calls save() to trigger Mongoose validation and middleware
+ * - User ownership enforced by fetching document with user filter
+ * - Uniqueness validation uses ensureUnique when relevant fields change
  * 
  * Uniqueness check optimization:
  * - Only validates uniqueness when unique fields are actually being modified
@@ -480,11 +491,11 @@ async function updateUserDoc(model, id, username, fieldsToUpdate, uniqueQuery, r
   try {
     // First, fetch the existing document to verify ownership and enable field comparison
     // This ensures users can only update documents they own and provides current values for comparison
-    const doc = await fetchUserDocOr404(model, id, username, res, 'Document not found');
+    const doc = await fetchUserDocOr404(model, id, username, res, 'Document not found'); // ensures caller owns document
     
     // If document not found, fetchUserDocOr404 already sent 404 response to client
     // Return undefined to signal that HTTP response was already sent
-    if (!doc) {
+    if (!doc) { // fetchUserDocOr404 already handled response
       logFunctionExit('updateUserDoc', 'undefined');
       console.log('updateUserDoc is returning undefined'); // Not found logging helps debug missing documents
       return; // Early return prevents further processing when document doesn't exist
@@ -492,7 +503,7 @@ async function updateUserDoc(model, id, username, fieldsToUpdate, uniqueQuery, r
     
     // Check if uniqueness validation is needed using extracted helper function
     // This separates change detection logic from update operations for better maintainability
-    if (hasUniqueFieldChanges(doc, fieldsToUpdate, uniqueQuery)) {
+    if (hasUniqueFieldChanges(doc, fieldsToUpdate, uniqueQuery)) { // only check DB when unique fields change
       // Build uniqueness query excluding the current document to avoid false positives
       // Without $ne exclusion, the document would conflict with itself during updates
       const uniqueQueryWithExclusion = {
@@ -502,7 +513,7 @@ async function updateUserDoc(model, id, username, fieldsToUpdate, uniqueQuery, r
       
       // Validate uniqueness using extracted helper function for consistent behavior
       // This centralizes uniqueness validation logic across create and update operations
-      if (!(await validateDocumentUniqueness(model, uniqueQueryWithExclusion, res, duplicateMsg))) {
+      if (!(await validateDocumentUniqueness(model, uniqueQueryWithExclusion, res, duplicateMsg))) { // duplicate of other doc found
         logFunctionExit('updateUserDoc', 'undefined');
         console.log('updateUserDoc is returning undefined'); // Duplicate logging shows uniqueness conflict
         return; // Early return when uniqueness validation fails - response already sent
@@ -512,11 +523,11 @@ async function updateUserDoc(model, id, username, fieldsToUpdate, uniqueQuery, r
     // Apply updates to document using Object.assign for partial update
     // Object.assign preserves unchanged fields while updating only specified fields
     // This pattern allows selective updates without overwriting entire document
-    Object.assign(doc, fieldsToUpdate);
+    Object.assign(doc, fieldsToUpdate); // merge new fields without dropping existing data
     
     // Save updated document to trigger validation and middleware
     // save() ensures all Mongoose validation rules and pre/post hooks execute
-    await doc.save();
+    await doc.save(); // run validation and persist updates
     
     logFunctionExit('updateUserDoc', doc);
     console.log(`updateUserDoc is returning ${doc}`); // Success logging shows updated document


### PR DESCRIPTION
## Summary
- clarify database operations with inline comments
- note how user ownership and uniqueness checks work

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6848d14153d48322b5734db3a97a316d