### PR TITLE
Remove unused http helpers from demo app

### DIFF
--- a/PRODUCTION-GUIDE.md
+++ b/PRODUCTION-GUIDE.md
@@ -14,18 +14,17 @@ npm install qmemory
 
 ### Basic Usage
 ```javascript
-const { 
-  createUniqueDoc, 
-  fetchUserDocOr404, 
-  sendSuccess, 
+const {
+  createUniqueDoc,
+  fetchUserDocOr404,
   ensureMongoDB,
-  MemStorage 
+  MemStorage
 } = require('qmemory');
 
 // Express.js integration example
 app.get('/api/health', (req, res) => {
   if (ensureMongoDB(res)) {
-    sendSuccess(res, 'Service healthy');
+    res.status(200).json({ message: 'Service healthy' });
   }
 });
 ```
@@ -133,16 +132,16 @@ router.get('/documents/:id', async (req, res) => {
 
 ### HTTP Response Utilities
 ```javascript
-const { sendSuccess, sendBadRequest, sendInternalServerError } = require('qmemory');
+const { sendInternalServerError } = require('qmemory');
 
 // Standardized success responses
 app.post('/api/users', async (req, res) => {
   try {
     const user = await createUser(req.body);
-    sendSuccess(res, 'User created successfully', user);
+    res.status(201).json({ message: 'User created successfully', data: user });
   } catch (error) {
     if (error.code === 'VALIDATION_ERROR') {
-      sendBadRequest(res, error.message);
+      res.status(400).json({ message: error.message });
     } else {
       sendInternalServerError(res, 'Failed to create user');
     }
@@ -207,7 +206,7 @@ mongoose.connection.on('disconnected', () => {
 
 ### Health Check Endpoint
 ```javascript
-const { ensureMongoDB, sendSuccess, sendServiceUnavailable } = require('qmemory');
+const { ensureMongoDB, sendServiceUnavailable } = require('qmemory');
 
 app.get('/health', (req, res) => {
   const checks = {
@@ -218,7 +217,7 @@ app.get('/health', (req, res) => {
   };
   
   if (checks.database) {
-    sendSuccess(res, 'All systems operational', checks);
+    res.status(200).json({ message: 'All systems operational', data: checks });
   }
   // Database check already sent 503 response if failed
 });
@@ -282,7 +281,7 @@ app.post('/api/documents', [
 ], async (req, res) => {
   const errors = validationResult(req);
   if (!errors.isEmpty()) {
-    return sendBadRequest(res, 'Invalid input data');
+    return res.status(400).json({ message: 'Invalid input data' });
   }
   
   // Proceed with document creation

--- a/demo-app.js
+++ b/demo-app.js
@@ -20,19 +20,41 @@
  */
 
 const express = require('express');
-const { 
+const {
   MemStorage,
-  sendSuccess,
-  sendBadRequest,
   sendNotFound,
   sendInternalServerError,
-  ensureMongoDB,
-  logInfo,
-  logError
+  ensureMongoDB
 } = require('./index');
 
 const app = express();
 const port = process.env.PORT || 5000;
+
+// Local helper functions provide minimal implementations since the library
+// no longer exports these utilities
+function logInfo(...args) { console.log('[INFO]', ...args); } // unify info logging
+function logError(...args) { console.error('[ERROR]', ...args); } // unify error logging
+function sendSuccess(res, message, data) { // send standard 200 response
+  console.log(`sendSuccess is running with ${message}`); // trace call for debugging
+  try {
+    const payload = { message, timestamp: new Date().toISOString() };
+    if (data !== undefined) payload.data = data; // include optional data
+    res.status(200).json(payload);
+    console.log(`sendSuccess is returning ${JSON.stringify(payload)}`); // confirm output
+  } catch (error) {
+    console.error('sendSuccess failed', error); // log failure path
+  }
+}
+function sendBadRequest(res, message) { // send standard 400 response
+  console.log(`sendBadRequest is running with ${message}`); // trace call for debugging
+  try {
+    const payload = { message, timestamp: new Date().toISOString() };
+    res.status(400).json(payload);
+    console.log('sendBadRequest has run resulting in a final value of 400'); // confirm completion
+  } catch (error) {
+    console.error('sendBadRequest failed', error); // log failure path
+  }
+}
 
 // Middleware
 app.use(express.json()); // body parser for JSON payloads, ensures consistent req.body


### PR DESCRIPTION
## Summary
- strip nonexistent helper imports from demo-app
- provide simple local implementations of sendSuccess, sendBadRequest, logInfo and logError
- update Production Guide examples to use standard Express responses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68491c3d8efc8322be2280cccda2176d