### PR TITLE
Trim usernames and prevent spaced duplicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ const userStorage = new MemStorage();
 #### Storage Methods
 
 ##### createUser(insertUser)
-Creates a new user with auto-generated ID.
+Creates a new user with auto-generated ID. Usernames are automatically trimmed of leading and trailing whitespace.
 
 ```javascript
 const user = await storage.createUser({

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -149,7 +149,7 @@ class MemStorage {
    */
   normalizeUserFields(insertUser) {
     return {
-      username: insertUser.username,
+      username: insertUser.username.trim(), // remove extraneous spaces for consistent duplicates
       displayName: insertUser.displayName ?? null, // Convert undefined to null
       githubId: insertUser.githubId ?? null,       // Convert undefined to null
       avatar: insertUser.avatar ?? null,           // Convert undefined to null
@@ -188,12 +188,14 @@ class MemStorage {
     if (!insertUser || typeof insertUser.username !== 'string' || insertUser.username.trim().length === 0) {
       throw new Error('Username is required and must be a non-empty string');
     }
-    
+
+    const trimmedUsername = insertUser.username.trim(); // single value for duplicate check
+
     // Check for duplicate username to prevent data conflicts
     // This linear search is acceptable for development scenarios with limited users
-    const existingUser = await this.getUserByUsername(insertUser.username);
+    const existingUser = await this.getUserByUsername(trimmedUsername); // lookup with trimmed value
     if (existingUser) {
-      throw new Error(`Username '${insertUser.username}' already exists`);
+      throw new Error(`Username '${trimmedUsername}' already exists`); // use normalized name in message
     }
     
     // Generate unique numeric ID then bump the counter for future calls
@@ -202,7 +204,7 @@ class MemStorage {
     
     // Transform InsertUser to User format with proper null handling
     // Use helper function to normalize fields consistently across all user operations
-    const normalizedFields = this.normalizeUserFields(insertUser);
+    const normalizedFields = this.normalizeUserFields({ ...insertUser, username: trimmedUsername }); // ensure stored username lacks spaces
     const user = {
       id,
       ...normalizedFields

--- a/test/unit/storage.test.js
+++ b/test/unit/storage.test.js
@@ -116,6 +116,12 @@ describe('MemStorage Class', () => { // tests behavior of the in-memory storage 
       await expect(memStorage.createUser({ username: 'testuser' })).rejects.toThrow("Username 'testuser' already exists");
     }); // Tests new uniqueness validation for production safety
 
+    test('should trim username and detect duplicates with spacing', async () => { // spaces should not avoid duplicate
+      const user = await memStorage.createUser({ username: ' user ' });
+      expect(user.username).toBe('user');
+      await expect(memStorage.createUser({ username: 'user' })).rejects.toThrow("Username 'user' already exists");
+    });
+
     test('should store user with all fields', async () => { // handles full payload
       const insertUser = {
         username: 'fulluser',


### PR DESCRIPTION
## Summary
- trim username during field normalization
- check duplicates with trimmed value when creating users
- test trimmed username duplicates
- document username trimming in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68499c2796b48322a08f42085eeb507e