### PR TITLE
Fix user creation doc example

### DIFF
--- a/PRODUCTION-GUIDE.md
+++ b/PRODUCTION-GUIDE.md
@@ -137,7 +137,7 @@ const { sendInternalServerError } = require('qmemory');
 // Standardized success responses
 app.post('/api/users', async (req, res) => {
   try {
-    const user = await createUser(req.body);
+    const user = await storage.createUser(req.body); // use the memory storage instance for user creation
     res.status(201).json({ message: 'User created successfully', data: user });
   } catch (error) {
     if (error.code === 'VALIDATION_ERROR') {


### PR DESCRIPTION
## Summary
- use `storage.createUser` in HTTP response utilities example

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68499c2a273c8322aba465621bad391b