### PR TITLE
Prevent user field updates

### DIFF
--- a/lib/document-ops.js
+++ b/lib/document-ops.js
@@ -487,8 +487,12 @@ async function createUniqueDoc(model, fields, uniqueQuery, res, duplicateMsg) {
 async function updateUserDoc(model, id, username, fieldsToUpdate, uniqueQuery, res, duplicateMsg) {
   console.log(`updateUserDoc is running with id: ${id} user: ${username}`); // Entry logging tracks update attempts
   logFunctionEntry('updateUserDoc', { id, username });
-  
+
   try {
+    if (Object.prototype.hasOwnProperty.call(fieldsToUpdate, 'user')) { // check for attempted ownership change
+      console.warn(`updateUserDoc ignored user change for doc: ${id}`); // warn when user field is present
+      delete fieldsToUpdate.user; // prevent modification of document ownership
+    }
     // First, fetch the existing document to verify ownership and enable field comparison
     // This ensures users can only update documents they own and provides current values for comparison
     const doc = await fetchUserDocOr404(model, id, username, res, 'Document not found'); // ensures caller owns document

--- a/test/unit/document-ops.test.js
+++ b/test/unit/document-ops.test.js
@@ -422,6 +422,24 @@ describe('Document Operations Module', () => { // Unit tests for higher-level do
       expect(mockDocInstance.save).toHaveBeenCalled();
       expect(result).toBeDefined();
     });
+
+    test('should ignore attempts to change user field', async () => { // ensures user ownership cannot be updated
+      const fieldsToUpdate = { user: 'malicious', title: 'Updated Title' };
+
+      mockModel.findOne.mockResolvedValue(mockDocInstance);
+      mockDocInstance.save.mockResolvedValue({
+        ...mockDocInstance,
+        title: 'Updated Title'
+      });
+
+      const result = await updateUserDoc(
+        mockModel, '123', 'testuser', fieldsToUpdate, null, mockRes, 'Duplicate'
+      );
+
+      expect(result.user).toBe('testuser');
+      expect(console.warn).toHaveBeenCalled();
+      expect(mockDocInstance.save).toHaveBeenCalled();
+    });
   });
   // Helper functions to create mock objects
   function createMockModel() {


### PR DESCRIPTION
## Summary
- warn and ignore attempts to update document owner in `updateUserDoc`
- add unit test ensuring owner field isn't modified

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6849d9eaf9748322b591c76883c0da9c