### PR TITLE
Add numeric ID validation

### DIFF
--- a/demo-app.js
+++ b/demo-app.js
@@ -162,7 +162,10 @@ app.post('/users', async (req, res) => { // create a user for demo operations
 
 app.get('/users/:id', async (req, res) => { // fetch a single user by id
   try {
-    const id = parseInt(req.params.id); // parse id from path
+    const id = parseInt(req.params.id, 10); // parse as base-10 integer for clarity
+    if (!Number.isInteger(id) || !/^\d+$/.test(req.params.id)) { // validate numeric input strictly
+      return sendBadRequest(res, 'User ID must be numeric'); // reject non-numeric IDs with 400
+    }
     const user = await storage.getUser(id); // await user fetch to ensure data
 
     if (!user) { // handle unknown id
@@ -178,7 +181,10 @@ app.get('/users/:id', async (req, res) => { // fetch a single user by id
 
 app.delete('/users/:id', async (req, res) => { // remove a user by id
   try {
-    const id = parseInt(req.params.id); // parse id safely
+    const id = parseInt(req.params.id, 10); // parse as base-10 integer for consistency
+    if (!Number.isInteger(id) || !/^\d+$/.test(req.params.id)) { // enforce numeric id format
+      return sendBadRequest(res, 'User ID must be numeric'); // reject invalid ids with 400
+    }
     const deleted = await storage.deleteUser(id); // await deletion result
 
     if (!deleted) { // handle missing user

--- a/test/integration/demo-app.test.js
+++ b/test/integration/demo-app.test.js
@@ -96,6 +96,11 @@ describe('Demo App API', () => {
     expect(res.status).toBe(404);
   });
 
+  test('GET /users/:id returns 400 when id is not numeric', async () => {
+    const res = await agent.get('/users/xyz');
+    expect(res.status).toBe(400);
+  });
+
   test('DELETE /users/:id succeeds for existing user', async () => {
     const createRes = await agent.post('/users').send({ username: 'carol' });
     const id = createRes.body.data.id;
@@ -106,6 +111,11 @@ describe('Demo App API', () => {
   test('DELETE /users/:id returns 404 when missing', async () => {
     const res = await agent.delete('/users/9999');
     expect(res.status).toBe(404);
+  });
+
+  test('DELETE /users/:id returns 400 when id is not numeric', async () => {
+    const res = await agent.delete('/users/10abc');
+    expect(res.status).toBe(400);
   });
 
   test('POST /users/clear resets storage when not in production', async () => {


### PR DESCRIPTION
## Summary
- validate numeric IDs in demo routes
- test GET and DELETE handlers with invalid IDs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6849d9f8f1ac832280fbd5e29b5785d0