### PR TITLE
Fix sanitizeMessage type check and add tests

### DIFF
--- a/lib/http-utils.js
+++ b/lib/http-utils.js
@@ -46,7 +46,15 @@ function validateResponseObject(res) { // validate object has expected methods f
  * @returns {string} Sanitized message or fallback
  */
 function sanitizeMessage(message, fallback) { // ensure clean error text for responses
-  return (message && message.trim()) || fallback; // use trimmed message when valid, otherwise use fallback to avoid empty strings
+  console.log(`sanitizeMessage is running with ${message}, ${fallback}`); // trace call parameters for debugging
+  if (typeof message !== 'string') { // confirm message is string before trimming to avoid errors
+    console.log(`sanitizeMessage is returning ${fallback}`); // log default path when input invalid
+    return fallback; // use fallback when message type is incorrect
+  }
+  const trimmed = message.trim(); // remove surrounding whitespace from message input
+  const result = trimmed || fallback; // choose fallback when trimmed string is empty
+  console.log(`sanitizeMessage is returning ${result}`); // log sanitized or fallback message
+  return result; // return final sanitized message
 }
 
 /**

--- a/test/unit/http-utils.test.js
+++ b/test/unit/http-utils.test.js
@@ -70,12 +70,30 @@ describe('HTTP Utils Module', () => { // Tests standardized HTTP response helper
 
     test('should handle long message', () => { // supports verbose errors
       const longMessage = 'A very long error message that describes exactly what went wrong in great detail';
-      
+
       sendNotFound(mockRes, longMessage);
-      
+
       expect(mockRes.status).toHaveBeenCalledWith(404);
-      expect(mockRes.json).toHaveBeenCalledWith({ 
+      expect(mockRes.json).toHaveBeenCalledWith({
         message: longMessage,
+        timestamp: expect.any(String)
+      });
+    });
+
+    test('should provide default message for non-string values', () => { // ensures fallback when message is not string
+      sendNotFound(mockRes, 123);
+
+      expect(mockRes.status).toHaveBeenCalledWith(404);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: 'Resource not found',
+        timestamp: expect.any(String)
+      });
+
+      sendNotFound(mockRes, { error: 'not string' });
+
+      expect(mockRes.status).toHaveBeenCalledWith(404);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: 'Resource not found',
         timestamp: expect.any(String)
       });
     });
@@ -98,7 +116,17 @@ describe('HTTP Utils Module', () => { // Tests standardized HTTP response helper
       sendConflict(mockRes, null);
       
       expect(mockRes.status).toHaveBeenCalledWith(409);
-      expect(mockRes.json).toHaveBeenCalledWith({ 
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: 'Resource conflict',
+        timestamp: expect.any(String)
+      });
+    });
+
+    test('should provide default message for non-string values', () => { // ensures fallback when message is not string
+      sendConflict(mockRes, true);
+
+      expect(mockRes.status).toHaveBeenCalledWith(409);
+      expect(mockRes.json).toHaveBeenCalledWith({
         message: 'Resource conflict',
         timestamp: expect.any(String)
       });
@@ -126,7 +154,17 @@ describe('HTTP Utils Module', () => { // Tests standardized HTTP response helper
       sendInternalServerError(mockRes, null);
       
       expect(mockRes.status).toHaveBeenCalledWith(500);
-      expect(mockRes.json).toHaveBeenCalledWith({ 
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: 'Internal server error',
+        timestamp: expect.any(String)
+      });
+    });
+
+    test('should provide default message for non-string values', () => { // ensures fallback when message is not string
+      sendInternalServerError(mockRes, 500);
+
+      expect(mockRes.status).toHaveBeenCalledWith(500);
+      expect(mockRes.json).toHaveBeenCalledWith({
         message: 'Internal server error',
         timestamp: expect.any(String)
       });
@@ -151,7 +189,18 @@ describe('HTTP Utils Module', () => { // Tests standardized HTTP response helper
       sendServiceUnavailable(mockRes, null);
       
       expect(mockRes.status).toHaveBeenCalledWith(503);
-      expect(mockRes.json).toHaveBeenCalledWith({ 
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: 'Service temporarily unavailable',
+        timestamp: expect.any(String),
+        retryAfter: '300'
+      });
+    });
+
+    test('should provide default message for non-string values', () => { // ensures fallback when message is not string
+      sendServiceUnavailable(mockRes, false);
+
+      expect(mockRes.status).toHaveBeenCalledWith(503);
+      expect(mockRes.json).toHaveBeenCalledWith({
         message: 'Service temporarily unavailable',
         timestamp: expect.any(String),
         retryAfter: '300'


### PR DESCRIPTION
## Summary
- verify message is a string in `sanitizeMessage`
- return fallback when message isn't a string or trims empty
- test non-string message cases for HTTP utils

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6849f43a88dc83229420d3844e5987c1