### PR TITLE
Fix updateUserDoc mutation

### DIFF
--- a/lib/document-ops.js
+++ b/lib/document-ops.js
@@ -489,9 +489,11 @@ async function updateUserDoc(model, id, username, fieldsToUpdate, uniqueQuery, r
   logFunctionEntry('updateUserDoc', { id, username });
 
   try {
-    if (Object.prototype.hasOwnProperty.call(fieldsToUpdate, 'user')) { // check for attempted ownership change
+    const updates = { ...fieldsToUpdate }; // copy to avoid mutating caller data
+
+    if (Object.prototype.hasOwnProperty.call(updates, 'user')) { // check for attempted ownership change
       console.warn(`updateUserDoc ignored user change for doc: ${id}`); // warn when user field is present
-      delete fieldsToUpdate.user; // prevent modification of document ownership
+      delete updates.user; // prevent modification of document ownership
     }
     // First, fetch the existing document to verify ownership and enable field comparison
     // This ensures users can only update documents they own and provides current values for comparison
@@ -507,7 +509,7 @@ async function updateUserDoc(model, id, username, fieldsToUpdate, uniqueQuery, r
     
     // Check if uniqueness validation is needed using extracted helper function
     // This separates change detection logic from update operations for better maintainability
-    if (hasUniqueFieldChanges(doc, fieldsToUpdate, uniqueQuery)) { // only check DB when unique fields change
+    if (hasUniqueFieldChanges(doc, updates, uniqueQuery)) { // only check DB when unique fields change
       // Build uniqueness query excluding the current document to avoid false positives
       // Without $ne exclusion, the document would conflict with itself during updates
       const uniqueQueryWithExclusion = {
@@ -527,7 +529,7 @@ async function updateUserDoc(model, id, username, fieldsToUpdate, uniqueQuery, r
     // Apply updates to document using Object.assign for partial update
     // Object.assign preserves unchanged fields while updating only specified fields
     // This pattern allows selective updates without overwriting entire document
-    Object.assign(doc, fieldsToUpdate); // merge new fields without dropping existing data
+    Object.assign(doc, updates); // merge new fields without dropping existing data
     
     // Save updated document to trigger validation and middleware
     // save() ensures all Mongoose validation rules and pre/post hooks execute

--- a/test/unit/document-ops.test.js
+++ b/test/unit/document-ops.test.js
@@ -440,6 +440,23 @@ describe('Document Operations Module', () => { // Unit tests for higher-level do
       expect(console.warn).toHaveBeenCalled();
       expect(mockDocInstance.save).toHaveBeenCalled();
     });
+
+    test('should not mutate fieldsToUpdate object', async () => { // preserves caller data integrity
+      const fieldsToUpdate = { user: 'malicious', title: 'Updated Title' };
+      const original = { ...fieldsToUpdate }; // snapshot original state for comparison
+
+      mockModel.findOne.mockResolvedValue(mockDocInstance);
+      mockDocInstance.save.mockResolvedValue({
+        ...mockDocInstance,
+        title: 'Updated Title'
+      });
+
+      await updateUserDoc(
+        mockModel, '123', 'testuser', fieldsToUpdate, null, mockRes, 'Duplicate'
+      );
+
+      expect(fieldsToUpdate).toEqual(original); // ensure object remains unchanged
+    });
   });
   // Helper functions to create mock objects
   function createMockModel() {


### PR DESCRIPTION
## Summary
- copy update payloads in updateUserDoc to avoid mutating callers
- update tests for updateUserDoc and add a mutation check

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_684a1f753cf88322b62a3d92b3d91778