### PR TITLE
Fix MemStorage capacity check

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -199,14 +199,18 @@ class MemStorage {
 
     const trimmedUsername = insertUser.username.trim(); // single value for duplicate check
 
+    if (this.users.size >= this.maxUsers) { // check capacity before async ops
+      throw new Error('Maximum user limit reached'); // fail fast when full
+    }
+
     // Check for duplicate username to prevent data conflicts
     // This linear search is acceptable for development scenarios with limited users
     const existingUser = await this.getUserByUsername(trimmedUsername); // lookup with trimmed value
     if (existingUser) {
       throw new Error(`Username '${trimmedUsername}' already exists`); // use normalized name in message
     }
-    
-    if (this.users.size >= this.maxUsers) { // enforce optional limit on users
+
+    if (this.users.size >= this.maxUsers) { // enforce limit after async check
       throw new Error('Maximum user limit reached'); // stop when capacity full
     }
 

--- a/test/unit/storage.test.js
+++ b/test/unit/storage.test.js
@@ -175,6 +175,18 @@ describe('MemStorage Class', () => { // tests behavior of the in-memory storage 
       await limited.createUser({ username: 'first' });
       await expect(limited.createUser({ username: 'second' })).rejects.toThrow('Maximum user limit reached');
     });
+
+    test('should handle concurrent createUser calls hitting limit', async () => { // second call rejected once full
+      const limited = new MemStorage(1);
+      const firstPromise = limited.createUser({ username: 'concurrent1' }); // start first user create
+      const secondPromise = limited.createUser({ username: 'concurrent2' }); // start second user create
+
+      await expect(secondPromise).rejects.toThrow('Maximum user limit reached');
+      const firstUser = await firstPromise;
+      expect(firstUser.username).toBe('concurrent1');
+      const allUsers = await limited.getAllUsers();
+      expect(allUsers).toHaveLength(1);
+    });
   });
 
   describe('getUser', () => { // ensure retrieval by ID behaves as expected


### PR DESCRIPTION
## Summary
- enforce `maxUsers` before and after duplicate lookup in MemStorage
- test concurrent `createUser` rejection once capacity hit

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684a1f7db91c8322b3fe5e6f58c70128