### PR TITLE
Update docs for correct createUser usage

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -112,10 +112,10 @@ const storage = require('qmemory').storage;
 
 if (process.env.NODE_ENV === 'development') {
   // Uses MemStorage automatically
-  const user = storage.createUser('testuser', { email: 'test@example.com' });
+  const user = storage.createUser({ username: 'testuser' }); // MemStorage only stores username
 } else {
   // Uses MongoDB document operations
-  const user = await createUniqueDoc(UserModel, 'testuser', { email: 'test@example.com' });
+  const user = await createUniqueDoc(UserModel, { username: 'testuser' });
 }
 ```
 

--- a/PRODUCTION-GUIDE.md
+++ b/PRODUCTION-GUIDE.md
@@ -137,7 +137,7 @@ const { sendInternalServerError } = require('qmemory');
 // Standardized success responses
 app.post('/api/users', async (req, res) => {
   try {
-    const user = await storage.createUser(req.body); // use the memory storage instance for user creation
+    const user = await storage.createUser({ username: req.body.username }); // pass only supported fields
     res.status(201).json({ message: 'User created successfully', data: user });
   } catch (error) {
     if (error.code === 'VALIDATION_ERROR') {
@@ -156,9 +156,9 @@ const { MemStorage } = require('qmemory');
 // Development environment user management
 if (process.env.NODE_ENV !== 'production') {
   const storage = new MemStorage();
-  
+
   // Create test users
-  await storage.createUser({ username: 'testuser', email: 'test@example.com' });
+  await storage.createUser({ username: 'testuser' }); // MemStorage ignores email
   
   // Development-only endpoints
   app.get('/dev/users', (req, res) => {


### PR DESCRIPTION
## Summary
- clarify `createUser` usage in deployment docs
- show `createUser` with supported `{ username }` object only
- note that email is ignored by `MemStorage`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684a84325bdc8322ba61be846ae75d83