### PR TITLE
Update docs for utility behavior

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -9,7 +9,7 @@ This Node.js utility library is ready for deployment as an npm package or for in
 ### Required Dependencies
 - Node.js 18+ or 20+
 - MongoDB 4.4+ (for production use)
-- Mongoose 7.0+
+- Mongoose 8.0+
 
 ### Development Dependencies
 - Jest for testing

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A comprehensive Node.js utility library providing MongoDB document operations, H
 
 - Node.js 18+
 - MongoDB 4.4+ (for production mode)
+- Mongoose 8+ (peer dependency)
 
 ## Installation
 
@@ -71,6 +72,9 @@ const {
 ## API Reference
 
 ### HTTP Utilities
+
+All HTTP utility functions return the Express response object so additional calls
+can be chained in your route handlers.
 
 #### sendNotFound(res, message)
 Sends a standardized 404 Not Found response.


### PR DESCRIPTION
## Summary
- state mongoose version in requirements
- note that HTTP utils return the `res` object
- bump mongoose version in deployment guide

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e1726e5288322a55c6d49bc5041c3