### PR TITLE
Clarify demo server port usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ For a working example of the library, run the included demo server:
 NODE_ENV=development node demo-app.js
 ```
 
-The server starts on port `5000` and exposes basic user management routes for exploration.
+The server uses `PORT` if set; otherwise it starts on `5000` and exposes basic user management routes for exploration.
 
 ## Performance Considerations
 


### PR DESCRIPTION
## Summary
- update README to specify that the demo server checks the `PORT` env variable and defaults to `5000`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684e1d65aacc8322b6f4767145d13228